### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 HOST=host   #optional
 PORT=port_number   #optional
 PUBLIC_URL=url_of_the_deployed_m3u8_server #mandatory
-ALLOWED_ORIGINS=https://site1.com,https://site2.com   #mandatory
+ALLOWED_ORIGINS=https://site1.com,https://site2.com,   #mandatory and keep the (comma ,) at the end!


### PR DESCRIPTION
m3u8proxy only works if there is a comma at the end of the allowed_origins.